### PR TITLE
Implement #[inert::neutralize(as Self)]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,28 @@
 [package]
 name = "inert"
-version = "0.2.1" # update `documentation` link on bump
+version = "0.2.2" # update `documentation` link on bump
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
-description = "Inert lets you use non-Sync values in Sync context"
+edition = "2018"
+description = "Inert lets you use non-Sync values in a Sync way"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/nox/inert"
-documentation = "https://docs.rs/inert/0.2.1/"
-readme = "README.md"
+documentation = "https://docs.rs/inert/0.2.2/"
 categories = ["concurrency", "data-structures"]
 keywords = ["sync", "thread"]
-exclude = ["/bors.toml", "/.travis.yml", "/.vscode"]
 
 [features]
 std = []
 
 [lib]
 test = false
+
+[dependencies]
+inert_derive = {version = "0.1.0", path = "derive"}
+
+[workspace]
+members = [
+    "derive",
+]
 
 [[test]]
 name = "refcells"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Inert
 
-This is a mechanism to access non-`Sync` values in `Sync` contexts.
+This is a mechanism to access non-`Sync` values in a `Sync` way.
 
 ## How is this sound?
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "inert_derive"
+version = "0.1.0" # update `documentation` link on bump
+authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
+edition = "2018"
+description = "See the inert crate"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/nox/inert"
+documentation = "https://docs.rs/inert_derive/0.1.0/"
+categories = ["concurrency", "data-structures"]
+keywords = ["sync", "thread"]
+exclude = ["/bors.toml", "/.travis.yml", "/.vscode/**"]
+
+[lib]
+proc-macro = true
+test = false
+
+[dependencies]
+proc-macro2 = "0.4.27"
+quote = "0.6.11"
+syn = {version = "0.15.26", features = ["parsing"]}
+synstructure = "0.10.1"

--- a/derive/LICENSE-APACHE
+++ b/derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/derive/LICENSE-MIT
+++ b/derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,66 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{self, Parse, ParseStream};
+use syn::{self, DeriveInput, Token};
+use synstructure::{AddBounds, Structure};
+
+/// Derives neutralizing traits.
+///
+/// For now, there is only one syntax accepted by this macro attribute.
+///
+/// ### `#[inert::neutralize(as Self)]`
+///
+/// Implements `NeutralizeUnsafe` with `type Output = Self;`. Given that this
+/// can type check if and only if `Self` is `Sync`, the traits `Neutralize`
+/// and `NeutralizeMut` are also automatically implemented.
+#[proc_macro_attribute]
+pub fn neutralize(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut result = item.clone();
+
+    let attr = syn::parse_macro_input!(attr as NeutralizeAttr);
+    let input = syn::parse_macro_input!(item as DeriveInput);
+    let mut structure = Structure::new(&input);
+
+    structure.add_bounds(AddBounds::None);
+
+    #[allow(non_snake_case)]
+    match attr {
+        NeutralizeAttr::AsSelf(Self_) => {
+            // https://github.com/mystor/synstructure/issues/25
+            result.extend(TokenStream::from(structure.gen_impl(quote! {
+                extern crate inert;
+
+                gen unsafe impl ::inert::Neutralize for @Self {}
+            })));
+            result.extend(TokenStream::from(structure.gen_impl(quote! {
+                extern crate inert;
+
+                gen unsafe impl ::inert::NeutralizeMut for @Self {}
+            })));
+            result.extend(TokenStream::from(structure.gen_impl(quote! {
+                extern crate inert;
+
+                gen unsafe impl ::inert::NeutralizeUnsafe for @Self {
+                    type Output = #Self_;
+
+                    unsafe fn neutralize_unsafe(&self) -> &Self::Output { self }
+                }
+            })));
+        },
+    };
+
+    result
+}
+
+enum NeutralizeAttr {
+    AsSelf(Token![Self]),
+}
+
+impl Parse for NeutralizeAttr {
+    fn parse(input: ParseStream) -> parse::Result<Self> {
+        input.parse::<Token![as]>()?;
+        input.parse().map(NeutralizeAttr::AsSelf)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[doc(inline)]
+pub use inert_derive::neutralize;
+
 #[cfg(feature = "std")]
 extern crate core;
 

--- a/tests/refcells.rs
+++ b/tests/refcells.rs
@@ -9,22 +9,25 @@ fn inert_new_mut() {
     let mut tree = tree();
     let inert = Inert::new_mut(&mut tree);
 
-    assert_eq!(&**inert.name(), "premature optimisation");
+    assert_eq!(inert.name().0, "premature optimisation");
 
     let wrath = &inert.children()[4];
-    assert_eq!(&**wrath.name(), "wrath");
+    assert_eq!(wrath.name().0, "wrath");
 
     let me = &wrath.children()[0];
-    assert_eq!(&**me.name(), "nox");
+    assert_eq!(me.name().0, "nox");
 
     let best_language_ever = &inert.children()[0].children()[0];
-    assert_eq!(&**best_language_ever.name(), "coq");
+    assert_eq!(best_language_ever.name().0, "coq");
 }
 
 struct Node {
-    name: String,
+    name: Name,
     children: Vec<RefCell<Node>>,
 }
+
+#[inert::neutralize(as Self)]
+struct Name(String);
 
 fn tree() -> RefCell<Node> {
     let mut root = Node::new("premature optimisation");
@@ -86,9 +89,9 @@ unsafe impl Sync for InertNode {}
 unsafe impl NeutralizeMut for Node {}
 
 impl InertNode {
-    fn name(&self) -> &Inert<String> {
+    fn name(&self) -> &Inert<Name> {
         // Compile check that tells us that `String` is `NeutralizeMut`.
-        let _ = <Inert<String>>::new_mut;
+        let _ = <Inert<Name>>::new_mut;
         unsafe { Inert::new_unchecked(&self.value.name) }
     }
 
@@ -102,7 +105,7 @@ impl InertNode {
 
 impl Node {
     fn new(name: &str) -> RefCell<Self> {
-        RefCell::new(Self { name: name.into(), children: vec![] })
+        RefCell::new(Self { name: Name(name.into()), children: vec![] })
     }
 
     fn append_child(&mut self, child: RefCell<Self>) {


### PR DESCRIPTION
This is very primitive and will only work on types that are `Sync` without any additional trait bounds. Baby steps.