### PR TITLE
derive: make getters #[inline]

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -255,6 +255,7 @@ fn inert_methods<'input>(
 
         methods.extend(quote_spanned! {field.ty.span()=>
             #[allow(unsafe_code)]
+            #[inline]
             #vis fn #getter_name(&self) -> &inert::Inert<#ty> {
                 unsafe { inert::Inert::new_unchecked(&self.value.as_ref().#field_name) }
             }


### PR DESCRIPTION
Tested using the Eyeballin' TM technique:
```
cargo expand --test refcells --color=never | grep -C 1 "fn name(" | grep inline && echo "yay, 🥖'" || echo "no chocolatine for you"
```

Before:
```
no chocolatine for you
```

After:
```
#[inline]
yay, 🥖
```

Fixes #9 